### PR TITLE
TASK: Use line-chart icon instead of bar-chart if available

### DIFF
--- a/Configuration/NodeTypes.yaml
+++ b/Configuration/NodeTypes.yaml
@@ -19,10 +19,11 @@
         stats:
           label: 'TYPO3.Neos.GoogleAnalytics:NodeTypes.StatsTabMixin:tabs.stats'
           position: 100
-          icon: 'icon-bar-chart'
+          icon: 'icon-bar-chart icon-line-chart'
       groups:
         analytics:
           label: 'TYPO3.Neos.GoogleAnalytics:NodeTypes.StatsTabMixin:groups.analytics'
+          icon: 'icon-line-chart'
           position: 10
           tab: 'stats'
       # All analytics metrics are "views" for the inspector

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -16,7 +16,7 @@ TYPO3:
             label: 'Analytics'
             controller: 'TYPO3\Neos\GoogleAnalytics\Controller\ConfigurationController'
             description: 'Google Analytics configuration'
-            icon: 'icon-bar-chart'
+            icon: 'icon-bar-chart icon-line-chart'
             privilegeTarget: 'TYPO3.Neos.GoogleAnalytics:Module.Administration.Configuration'
 
     typoScript:


### PR DESCRIPTION
When using with Neos 2.2+ additional icons are available and a better
suited line-chart icon is used. Fallback to bar-chart icon if below 2.2.

NEOS-1406