### PR TITLE
BUGFIX: Keep Google authentication token when flushing caches

### DIFF
--- a/Configuration/Caches.yaml
+++ b/Configuration/Caches.yaml
@@ -1,5 +1,4 @@
 TYPO3_Neos_GoogleAnalytics_Tokens:
   frontend: TYPO3\Flow\Cache\Frontend\StringFrontend
   backend: TYPO3\Flow\Cache\Backend\SimpleFileBackend
-  backendOptions:
-    cacheDirectory: '%FLOW_PATH_DATA%Persistent/GoogleAnalyticsTokens'
+  persistent: true


### PR DESCRIPTION
The `TYPO3_Neos_GoogleAnalytics_Tokens` cache that stores the Google authentication token
was not configured to be persistent.
This change adjusts this by using a *persistent* Cache backend