### PR TITLE
BUGFIX: don't escape tracker config

### DIFF
--- a/Resources/Private/Templates/Prototypes/TrackingCode.html
+++ b/Resources/Private/Templates/Prototypes/TrackingCode.html
@@ -4,5 +4,5 @@
   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
   })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-  {code}
+  {code -> f:format.raw()}
 </script>


### PR DESCRIPTION
Otherwise you get this escaped output:
![image](https://cloud.githubusercontent.com/assets/837032/22640053/088ee916-ec62-11e6-8b59-561f2951b88f.png)
