### PR TITLE
BUGFIX: Invalid package type for Flow 3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "typo3/neos-googleanalytics",
-    "type": "typo3-flow-package",
+    "type": "neos-package",
     "description": "Google Analytics integration for Neos CMS",
     "license": "GPL-3.0+",
     "require": {
@@ -10,6 +10,11 @@
     "autoload": {
         "psr-4": {
             "TYPO3\\Neos\\GoogleAnalytics\\": "Classes"
+        }
+    },
+    "extra": {
+        "neos": {
+            "package-key": "Neos.GoogleAnalytics"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "typo3/neos-googleanalytics",
-    "type": "neos-package",
+    "type": "typo3-flow-package",
     "description": "Google Analytics integration for Neos CMS",
     "license": "GPL-3.0+",
     "require": {
@@ -10,11 +10,6 @@
     "autoload": {
         "psr-4": {
             "TYPO3\\Neos\\GoogleAnalytics\\": "Classes"
-        }
-    },
-    "extra": {
-        "neos": {
-            "package-key": "Neos.GoogleAnalytics"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "typo3/neos-googleanalytics",
-    "type": "neos-package",
+    "type": "typo3-flow-package",
     "description": "Google Analytics integration for Neos CMS",
     "license": "GPL-3.0+",
     "require": {


### PR DESCRIPTION
Type `neos-package` led to an incorrect package name in 
`PackageStates` and the Neos backend therefore couldn't find some files.