### PR TITLE
BUGFIX: Convert SiteConfiguration data to SiteConfiguration 

### DIFF
--- a/Classes/Controller/ConfigurationController.php
+++ b/Classes/Controller/ConfigurationController.php
@@ -74,7 +74,7 @@ class ConfigurationController extends \TYPO3\Flow\Mvc\Controller\ActionControlle
     /**
      * Update or add site configurations
      *
-     * @param array <\TYPO3\Neos\GoogleAnalytics\Domain\Model\SiteConfiguration> $siteConfigurations Array of site configurations
+     * @param array<\TYPO3\Neos\GoogleAnalytics\Domain\Model\SiteConfiguration> $siteConfigurations Array of site configurations
      * @return void
      */
     public function updateAction(array $siteConfigurations)


### PR DESCRIPTION
The SiteConfiguration was not converted to \TYPO3\Neos\GoogleAnalytics\Domain\Model\SiteConfiguration.
Therefore the data could not be persisted by the repository.

This bug was introduced by applying PSR-2 in neos/neos-googleanalytics@38c86896a4e7c083b3274b66e7b55adbc47841d3

This bug probably affects only Version 1.0.5 and 1.0.6

Resolves #23