### PR TITLE
BUGFIX: Add utf8mb4 support, persist old migrations

### DIFF
--- a/Migrations/Mysql/Version20141111161429.php
+++ b/Migrations/Mysql/Version20141111161429.php
@@ -15,23 +15,35 @@ class Version20141111161429 extends AbstractMigration {
 	 */
 	public function up(Schema $schema) {
 		$this->abortIf($this->connection->getDatabasePlatform()->getName() != "mysql");
-
-		$this->addSql("CREATE TABLE typo3_neos_googleanalytics_domain_model_siteconfiguration (persistence_object_identifier VARCHAR(40) NOT NULL, site VARCHAR(40) DEFAULT NULL, profileid VARCHAR(255) NOT NULL, INDEX IDX_D675F674694309E4 (site), PRIMARY KEY(persistence_object_identifier)) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB");
         /**
+         * With the new version of NEOS the recommended database charset is utf8mb4 and not just utf8 anymore.
+         * To make the foreign key constraint work the table/cell encoding must match the
+         * encoding of typo3_neos_domain_model_site / neos_domain_model_site.
+         * Solution: First check encoding of typo3_neos_domain_model_site / neos_domain_model_site,
+         * then create neos_googleanalytics_domain_model_siteconfiguration accordingly.
+         * AND
          * We need to check what the name of the site table is. If you install Neos, run migrations, then add this package,
          * then run this package's migrations, the name will will be neos_flow_...
          * However, if you install everything in one go and run migrations then, the order will be different because this migration
          * comes before the Flow migration where the table is renamed (Version20161124185047). So we need to check which of these two
          * tables exist and set the FK relation accordingly.
          **/
+
         if ($this->sm->tablesExist('neos_neos_domain_model_site')) {
-            // "neos_" table is there - this means flow migrations have already been run.
-            $this->addSql("ALTER TABLE typo3_neos_googleanalytics_domain_model_siteconfiguration ADD CONSTRAINT FK_D675F674694309E4 FOREIGN KEY (site) REFERENCES neos_neos_domain_model_site (persistence_object_identifier) ON DELETE CASCADE");
-        } else if ($this->sm->tablesExist('typo3_neos_domain_model_site')) {
-            // Flow migrations have not been run fully yet, table still has the old name.
-            $this->addSql("ALTER TABLE typo3_neos_googleanalytics_domain_model_siteconfiguration ADD CONSTRAINT FK_D675F674694309E4 FOREIGN KEY (site) REFERENCES typo3_neos_domain_model_site (persistence_object_identifier) ON DELETE CASCADE");
+            $tableName = 'neos_neos_domain_model_site';
+        } elseif ($this->sm->tablesExist('typo3_neos_domain_model_site')) {
+            $tableName = 'typo3_neos_domain_model_site';
+        } else {
+            return; // Nothing to do here
         }
-	}
+
+        $columnCharSets = $this->connection->executeQuery("SELECT character_set_name FROM information_schema.`COLUMNS` WHERE table_name = '${tableName}' AND column_name = 'persistence_object_identifier'")->fetch();
+
+        $charSet = $columnCharSets['character_set_name'];
+
+        $this->addSql("CREATE TABLE typo3_neos_googleanalytics_domain_model_siteconfiguration (persistence_object_identifier VARCHAR(40) NOT NULL, site VARCHAR(40) DEFAULT NULL, profileid VARCHAR(255) NOT NULL, INDEX IDX_D675F674694309E4 (site), PRIMARY KEY(persistence_object_identifier)) DEFAULT CHARACTER SET ${charSet} COLLATE ${charSet}_unicode_ci ENGINE = InnoDB");
+        $this->addSql("ALTER TABLE typo3_neos_googleanalytics_domain_model_siteconfiguration ADD CONSTRAINT FK_D675F674694309E4 FOREIGN KEY (site) REFERENCES ${tableName} (persistence_object_identifier) ON DELETE CASCADE");
+    }
 
 	/**
 	 * @param Schema $schema


### PR DESCRIPTION
As discussed (https://github.com/neos/neos-googleanalytics/pull/44) this Fix will solve migration issues with new the charset through editing the initial migration (as neos/neos did) to ensure UTF8mb4 compatibility.
