### PR TITLE
FEATURE: Tracking can be enabled via setting

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -22,6 +22,7 @@ Neos:
         'Neos.GoogleAnalytics': TRUE
 
   GoogleAnalytics:
+    enableTracking: true
 
     authentication:
       # Application name for the consent screen

--- a/Resources/Private/Fusion/Root.fusion
+++ b/Resources/Private/Fusion/Root.fusion
@@ -12,5 +12,7 @@ prototype(Neos.Neos:Page) {
 		# Include tracking code if a tracking id is configured for the current site
 		@if.trackingIdIsSet = ${!String.isBlank(this.trackingId)}
 
+		# Do not show if enableTracking is false
+		@if.trackingIsEnabled = ${Configuration.setting('Neos.GoogleAnalytics.enableTracking')}
 	}
 }


### PR DESCRIPTION
I have implemented a site-wide enableTracking setting. I think site-wide makes more sense then on site-specific.

```
Neos:
  GoogleAnalytics:
    enableTracking: true
```

Because of backward-compatibility, the default needs to be true.
