### PR TITLE
BUGFIX: fix charset detection logic to include the database

### DIFF
--- a/Migrations/Mysql/Version20141111161429.php
+++ b/Migrations/Mysql/Version20141111161429.php
@@ -37,7 +37,7 @@ class Version20141111161429 extends AbstractMigration {
             return; // Nothing to do here
         }
 
-        $columnCharSets = $this->connection->executeQuery("SELECT character_set_name FROM information_schema.`COLUMNS` WHERE table_name = '${tableName}' AND column_name = 'persistence_object_identifier'")->fetch();
+        $columnCharSets = $this->connection->executeQuery("SELECT character_set_name FROM information_schema.`COLUMNS` WHERE table_schema IN (SELECT DATABASE()) AND table_name = '${tableName}' AND column_name = 'persistence_object_identifier'")->fetch();
 
         $charSet = $columnCharSets['character_set_name'];
 


### PR DESCRIPTION
## Problem description

You have (at least) two different databases in your MySQL server instance - an OLD neos project with database still running UTF-8; and a NEW neos project with UTF8MB4.

In the NEW project, you want to include google analytics.

Now, without this change, it may happen that the OLD database table would be found in the charset detection query; thus effectively returning the wrong charset.

If this happens, the constraint (in the 2nd SQL statement) cannot be added correctly.

## Solution

Include the current database in the query.