### PR TITLE
BUGFIX: Fix icon for FA 5

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -17,7 +17,7 @@ Neos:
             label: 'Analytics'
             controller: 'Neos\GoogleAnalytics\Controller\ConfigurationController'
             description: 'Google Analytics configuration'
-            icon: 'icon-bar-chart icon-line-chart'
+            icon: 'icon-chart-line icon-line-chart'
             privilegeTarget: 'Neos.GoogleAnalytics:Module.Administration.Configuration'
 
     fusion:


### PR DESCRIPTION
As per https://fontawesome.com/icons?d=gallery&q=line-chart&m=free
the second icon assignment should be `icon-chart-line` to make it
work on the latest Neos.