### PR TITLE
BUGFIX: Stable check for used character set in migration

### DIFF
--- a/Migrations/Mysql/Version20141111161429.php
+++ b/Migrations/Mysql/Version20141111161429.php
@@ -37,8 +37,12 @@ class Version20141111161429 extends AbstractMigration {
             return; // Nothing to do here
         }
 
-        $columnCharSets = $this->connection->executeQuery("SELECT character_set_name FROM information_schema.`COLUMNS` WHERE table_schema IN (SELECT DATABASE()) AND table_name = '${tableName}' AND column_name = 'persistence_object_identifier'")->fetch();
-        $charSet = $columnCharSets['CHARACTER_SET_NAME'];
+        // the column name can come out of the query as upper or lower case
+        // (see https://github.com/neos/neos-googleanalytics/pull/70 and
+        // https://github.com/neos/neos-googleanalytics/issues/72 for details)
+        // - thus the AS is added.
+        $columnCharSets = $this->connection->executeQuery("SELECT character_set_name AS charsetname FROM information_schema.`COLUMNS` WHERE table_schema IN (SELECT DATABASE()) AND table_name = '${tableName}' AND column_name = 'persistence_object_identifier'")->fetch();
+        $charSet = $columnCharSets['charsetname'];
 
         $this->addSql("CREATE TABLE typo3_neos_googleanalytics_domain_model_siteconfiguration (persistence_object_identifier VARCHAR(40) NOT NULL, site VARCHAR(40) DEFAULT NULL, profileid VARCHAR(255) NOT NULL, INDEX IDX_D675F674694309E4 (site), PRIMARY KEY(persistence_object_identifier)) DEFAULT CHARACTER SET ${charSet} COLLATE ${charSet}_unicode_ci ENGINE = InnoDB");
         $this->addSql("ALTER TABLE typo3_neos_googleanalytics_domain_model_siteconfiguration ADD CONSTRAINT FK_D675F674694309E4 FOREIGN KEY (site) REFERENCES ${tableName} (persistence_object_identifier) ON DELETE CASCADE");


### PR DESCRIPTION
The column name can come out of the query used to determine the
character set as upper or lower case (see #70, #71 and #72.)

This uses "AS charsetname" to have a reliable key in the result.

Fixes #72