### PR TITLE
BUGFIX: Skip empty ga parameter

### DIFF
--- a/Resources/Private/Fusion/Prototypes/TrackingCode.GA.fusion
+++ b/Resources/Private/Fusion/Prototypes/TrackingCode.GA.fusion
@@ -17,15 +17,13 @@ prototype(Neos.GoogleAnalytics:TrackingCode.GA) < prototype(Neos.GoogleAnalytics
             create = 'window.dataLayer = window.dataLayer || [];'
             push = 'function gtag(){dataLayer.push(arguments);}'
             date = 'gtag("js", new Date());'
-            config = Neos.Fusion:Case {
-                hasParameters {
-                    condition = ${props.parameters && props.parameters != 'null' && props.parameters != '[]'}
-                    renderer = ${'gtag("config", "' + props.trackingId + '", ' + props.parameters + ');'}
-                }
-                default {
-                    condition = true
-                    renderer = ${'gtag("config", "' + props.trackingId + '");'}
-                }
+            config = Neos.Fusion:Join {
+                config = 'config'
+                trackingId = ${props.trackingId}
+                parameters = ${props.parameters}
+                parameters.@if.set = ${props.parameters && props.parameters != 'null' && props.parameters != '[]'}
+                @glue = ', '
+                @process.wrap = ${'gtag(' + value + ');'}
             }
         }
 

--- a/Resources/Private/Fusion/Prototypes/TrackingCode.GA.fusion
+++ b/Resources/Private/Fusion/Prototypes/TrackingCode.GA.fusion
@@ -17,7 +17,16 @@ prototype(Neos.GoogleAnalytics:TrackingCode.GA) < prototype(Neos.GoogleAnalytics
             create = 'window.dataLayer = window.dataLayer || [];'
             push = 'function gtag(){dataLayer.push(arguments);}'
             date = 'gtag("js", new Date());'
-            config = ${'gtag("config", "' + props.trackingId + '", ' + props.parameters + ');'}
+            config = Neos.Fusion:Case {
+                hasParameters {
+                    condition = ${props.parameters && props.parameters != 'null' && props.parameters != '[]'}
+                    renderer = ${'gtag("config", "' + props.trackingId + '", ' + props.parameters + ');'}
+                }
+                default {
+                    condition = true
+                    renderer = ${'gtag("config", "' + props.trackingId + '");'}
+                }
+            }
         }
 
         renderer = afx`


### PR DESCRIPTION
Re-created from https://github.com/neos/neos-googleanalytics/pull/77 for the (new) 3.2 branch.