### PR TITLE
Update TrackingCode.GA.fusion

### DIFF
--- a/Resources/Private/Fusion/Prototypes/TrackingCode.GA.fusion
+++ b/Resources/Private/Fusion/Prototypes/TrackingCode.GA.fusion
@@ -18,8 +18,8 @@ prototype(Neos.GoogleAnalytics:TrackingCode.GA) < prototype(Neos.GoogleAnalytics
             push = 'function gtag(){dataLayer.push(arguments);}'
             date = 'gtag("js", new Date());'
             config = Neos.Fusion:Join {
-                config = 'config'
-                trackingId = ${props.trackingId}
+                config = "'config'"
+                trackingId = ${"'"+props.trackingId+"'"}
                 parameters = ${props.parameters}
                 parameters.@if.set = ${props.parameters && props.parameters != 'null' && props.parameters != '[]'}
                 @glue = ', '

--- a/Resources/Private/Fusion/Prototypes/TrackingCode.GA.fusion
+++ b/Resources/Private/Fusion/Prototypes/TrackingCode.GA.fusion
@@ -5,7 +5,7 @@ prototype(Neos.GoogleAnalytics:TrackingCode.GA) < prototype(Neos.GoogleAnalytics
         hasTrackingId = ${!String.isBlank(this.trackingId)}
         hasNoContainerId = ${String.isBlank(this.configuration.tagManager.id)}
     }
-    
+
     parameters = ${this.configuration.analytics.parameters}
     parameters.@process.json = ${Json.stringify(value)}
 
@@ -17,13 +17,15 @@ prototype(Neos.GoogleAnalytics:TrackingCode.GA) < prototype(Neos.GoogleAnalytics
             create = 'window.dataLayer = window.dataLayer || [];'
             push = 'function gtag(){dataLayer.push(arguments);}'
             date = 'gtag("js", new Date());'
-            config = Neos.Fusion:Join {
-                config = 'config'
-                trackingId = ${props.trackingId}
-                parameters = ${props.parameters}
-                parameters.@if.set = ${props.parameters && props.parameters != 'null' && props.parameters != '[]'}
-                @glue = "', '"
-                @process.wrap = ${"gtag('" + value + "');"}
+            config = Neos.Fusion:Case {
+                hasParameters {
+                    condition = ${props.parameters && props.parameters != 'null' && props.parameters != '[]'}
+                    renderer = ${'gtag("config", "' + props.trackingId + '", ' + props.parameters + ');'}
+                }
+                default {
+                    condition = true
+                    renderer = ${'gtag("config", "' + props.trackingId + '");'}
+                }
             }
         }
 

--- a/Resources/Private/Fusion/Prototypes/TrackingCode.GA.fusion
+++ b/Resources/Private/Fusion/Prototypes/TrackingCode.GA.fusion
@@ -18,12 +18,12 @@ prototype(Neos.GoogleAnalytics:TrackingCode.GA) < prototype(Neos.GoogleAnalytics
             push = 'function gtag(){dataLayer.push(arguments);}'
             date = 'gtag("js", new Date());'
             config = Neos.Fusion:Join {
-                config = "'config'"
-                trackingId = ${"'"+props.trackingId+"'"}
+                config = 'config'
+                trackingId = ${props.trackingId}
                 parameters = ${props.parameters}
                 parameters.@if.set = ${props.parameters && props.parameters != 'null' && props.parameters != '[]'}
-                @glue = ', '
-                @process.wrap = ${'gtag(' + value + ');'}
+                @glue = "', '"
+                @process.wrap = ${"gtag('" + value + "');"}
             }
         }
 


### PR DESCRIPTION
As discussed [here](https://github.com/neos/neos-googleanalytics/commit/66fdecd4edab2b2ba4f32b408c81579fb67275d2#commitcomment-53168660) the Config-Values should be quoted again as as `gtag('config', 'UA-XXXXX'` instead of `gtag(config, UA-XXXXX`

This [Commit](https://github.com/neos/neos-googleanalytics/commit/66fdecd4edab2b2ba4f32b408c81579fb67275d2) from @DrillSergeant "broke" the Analytics Integration and throws a JS-Error after upgrading. I added `'` again to fix the issue. 

thanks for a quick release, event for the 3.2 version too @kdambekalns