### PR TITLE
Feature: Add further settings for URIs

### DIFF
--- a/Classes/Service/Reporting.php
+++ b/Classes/Service/Reporting.php
@@ -104,7 +104,7 @@ class Reporting
 
         $nodeUri = $this->getLiveNodeUri($node, $controllerContext);
         $hostname = !empty($siteConfiguration['overrideHostname']) ? $siteConfiguration['overrideHostname'] : $nodeUri->getHost();
-        $pagePathPrefix = !empty($siteConfiguration['pagePathPrefix']) ? $siteConfiguration['pagePathPrefix'] : '';
+        $pagePathPrefix = $siteConfiguration['pagePathPrefix'] ?? '';
         $includePagePath = !isset($siteConfiguration['includePagePath']) || $siteConfiguration['includePagePath'];
 
         $filters = 'ga:hostname==' . $hostname;

--- a/Classes/Service/Reporting.php
+++ b/Classes/Service/Reporting.php
@@ -108,7 +108,7 @@ class Reporting
         $includePagePath = !isset($siteConfiguration['includePagePath']) || $siteConfiguration['includePagePath'];
 
         $filters = 'ga:hostname==' . $hostname;
-        if($includePagePath){
+        if ($includePagePath) {
             $filters .= ';ga:pagePath==' . $pagePathPrefix . $nodeUri->getPath();
         }
         $parameters = [

--- a/Classes/Service/Reporting.php
+++ b/Classes/Service/Reporting.php
@@ -104,7 +104,13 @@ class Reporting
 
         $nodeUri = $this->getLiveNodeUri($node, $controllerContext);
         $hostname = !empty($siteConfiguration['overrideHostname']) ? $siteConfiguration['overrideHostname'] : $nodeUri->getHost();
-        $filters = 'ga:pagePath==' . $nodeUri->getPath() . ';ga:hostname==' . $hostname;
+        $pagePathPrefix = !empty($siteConfiguration['pagePathPrefix']) ? $siteConfiguration['pagePathPrefix'] : '';
+        $includePagePath = !isset($siteConfiguration['includePagePath']) || $siteConfiguration['includePagePath'];
+
+        $filters = 'ga:hostname==' . $hostname;
+        if($includePagePath){
+            $filters .= ';ga:pagePath==' . $pagePathPrefix . $nodeUri->getPath();
+        }
         $parameters = [
             'filters' => $filters
         ];

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -55,7 +55,7 @@ Neos:
       #
       # neosdemo:
       #   addToPagePrototype: false
-      #   pagePathPrefix: 'www.paessler.com'
+      #   pagePathPrefix: 'www.example.org'
       #   includePagePath: false
       #   profileId: '12345678'
       #   analytics:

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -55,8 +55,11 @@ Neos:
       #
       # neosdemo:
       #   addToPagePrototype: false
+      #   pagePathPrefix: 'www.paessler.com'
+      #   includePagePath: false
       #   profileId: '12345678'
       #   analytics:
       #     id: 'UA-XXXXX-YY'
       #   tagManager:
       #     id: GTM-XXXXX
+

--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -224,6 +224,8 @@ The configuration allows to override the hostname that is used for statistics qu
 By default the hostname is used that Neos provides based on the selected pages frontend uri.
 This can be used to verify the functionality of the statistics module during development
 or in staging environments.
+Additionally, there is a setting for prepending a string to the frontend uri. The frontend uri
+is automatically created.
 
 .. code-block:: yaml
 
@@ -232,6 +234,22 @@ or in staging environments.
       sites:
         neossitename:
           overrideHostname: 'example.org'
+          pagePathPrefix: '/neosuri'
+
+Show only page information
+----------------------------------------
+
+To show the information for the whole site and not only the current page,
+the setting 'includePagePath' can be set. This removes the filter for the frontend uri from
+the API request.
+
+.. code-block:: yaml
+
+  Neos:
+    GoogleAnalytics:
+      sites:
+        neossitename:
+          includePagePath: false
 
 
 Upgrade instructions (2.x -> 3.0.0)

--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -31,7 +31,7 @@ to set up tracking for each site in the Analytics integration.
     GoogleAnalytics:
       sites:
         ## All site specific settings are indexed by site node name
-        neossitename:
+        neosSiteName:
           analytics:
             id: 'UA-XXXXX-YY'
 
@@ -43,7 +43,7 @@ You can define them like this:
   Neos:
     GoogleAnalytics:
       sites:
-        neossitename:
+        neosSiteName:
           analytics:
             id: 'UA-XXXXX-YY'
             parameters:
@@ -56,7 +56,7 @@ Instead of using the Google Analytics tracking code, you can integrate the Googl
   Neos:
     GoogleAnalytics:
       sites:
-        neossitename:
+        neosSiteName:
           tagManager:
             id: 'GTM-XXXXX'
 
@@ -85,7 +85,7 @@ You can disable tracking for a site by either setting the  ``id `` to  ``false `
   Neos:
     GoogleAnalytics:
       sites:
-        neossitename:
+        neosSiteName:
           tagManager:
             id: false
             
@@ -99,7 +99,7 @@ If you are using the Google Analytics tracking code, you can also add additional
   Neos:
     GoogleAnalytics:
       sites:
-        neossitename:
+        neosSiteName:
           analytics:
             id: 'UA-XXXXX-YY'
             parameters:
@@ -181,7 +181,7 @@ The configuration should then look like this::
   Neos:
     GoogleAnalytics:
       sites:
-        neossitename:
+        neosSiteName:
           analytics:
             id: 'UA-XXXXX-YY'
           profileId: 123456789
@@ -232,7 +232,7 @@ is automatically created.
   Neos:
     GoogleAnalytics:
       sites:
-        neossitename:
+        neosSiteName:
           overrideHostname: 'example.org'
           pagePathPrefix: '/neosuri'
 
@@ -248,7 +248,7 @@ the API request.
   Neos:
     GoogleAnalytics:
       sites:
-        neossitename:
+        neosSiteName:
           includePagePath: false
 
 
@@ -262,7 +262,7 @@ Configuration for the tracking code has been changed:
   Neos:
     GoogleAnalytics:
       sites:
-        neossitename:
+        neosSiteName:
           analytics:
             id: 'UA-XXXXX-YY'
 


### PR DESCRIPTION
In our use case for googleanalytics, all URIs have a prefix. 

Example: 
Our uri in Google Analytics: neosdev/example
Uri request created by plugin: /example 

To fit our use case, I added a setting that adds a prefix to the uri request. 

Since I was already at it, I added a configuration to only show pagewide statistics. This should resolve #67 

closes #67

Also, I am not good at Documentation explanations, so suggestions welcome 😸 