### PR TITLE
BUGFIX: Change syntax from ${var} to {$var} to avoid PHP deprecation warning

### DIFF
--- a/Migrations/Mysql/Version20141111161429.php
+++ b/Migrations/Mysql/Version20141111161429.php
@@ -41,11 +41,11 @@ class Version20141111161429 extends AbstractMigration {
         // (see https://github.com/neos/neos-googleanalytics/pull/70 and
         // https://github.com/neos/neos-googleanalytics/issues/72 for details)
         // - thus the AS is added.
-        $columnCharSets = $this->connection->executeQuery("SELECT character_set_name AS charsetname FROM information_schema.`COLUMNS` WHERE table_schema IN (SELECT DATABASE()) AND table_name = '${tableName}' AND column_name = 'persistence_object_identifier'")->fetch();
+        $columnCharSets = $this->connection->executeQuery("SELECT character_set_name AS charsetname FROM information_schema.`COLUMNS` WHERE table_schema IN (SELECT DATABASE()) AND table_name = '{$tableName}' AND column_name = 'persistence_object_identifier'")->fetch();
         $charSet = $columnCharSets['charsetname'];
 
-        $this->addSql("CREATE TABLE typo3_neos_googleanalytics_domain_model_siteconfiguration (persistence_object_identifier VARCHAR(40) NOT NULL, site VARCHAR(40) DEFAULT NULL, profileid VARCHAR(255) NOT NULL, INDEX IDX_D675F674694309E4 (site), PRIMARY KEY(persistence_object_identifier)) DEFAULT CHARACTER SET ${charSet} COLLATE ${charSet}_unicode_ci ENGINE = InnoDB");
-        $this->addSql("ALTER TABLE typo3_neos_googleanalytics_domain_model_siteconfiguration ADD CONSTRAINT FK_D675F674694309E4 FOREIGN KEY (site) REFERENCES ${tableName} (persistence_object_identifier) ON DELETE CASCADE");
+        $this->addSql("CREATE TABLE typo3_neos_googleanalytics_domain_model_siteconfiguration (persistence_object_identifier VARCHAR(40) NOT NULL, site VARCHAR(40) DEFAULT NULL, profileid VARCHAR(255) NOT NULL, INDEX IDX_D675F674694309E4 (site), PRIMARY KEY(persistence_object_identifier)) DEFAULT CHARACTER SET {$charSet} COLLATE {$charSet}_unicode_ci ENGINE = InnoDB");
+        $this->addSql("ALTER TABLE typo3_neos_googleanalytics_domain_model_siteconfiguration ADD CONSTRAINT FK_D675F674694309E4 FOREIGN KEY (site) REFERENCES {$tableName} (persistence_object_identifier) ON DELETE CASCADE");
     }
 
 	/**


### PR DESCRIPTION
While updating our projects to PHP 8.3 and Neos 8.4, I came across the following error:

```
Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/Packages/Application/Neos.GoogleAnalytics/Migrations/Mysql/Version20141111161429.php on line 48
```

This PR migrates the syntax to the new version.